### PR TITLE
Optionally support multiple `listen` directives

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,13 @@ Please take note of the indentation in the above block. The first line should be
         return: "301 https://example.com$request_uri"
         filename: "example.com.80.conf"
 
+`listen` can also be an array of strings, which will result in multiple `listen` directives for that block.
+
+      - listen: ["80", "8080"]
+        server_name: "example.com www.example.com"
+        return: "301 https://example.com$request_uri"
+        filename: "example.com.80.conf"
+
 An example of a secondary vhost which will redirect to the one shown above.
 
 *Note: The `filename` defaults to the first domain in `server_name`, if you have two vhosts with the same domain, eg. a redirect, you need to manually set the `filename` so the second one doesn't override the first one*

--- a/templates/vhost.j2
+++ b/templates/vhost.j2
@@ -1,7 +1,9 @@
 {% block server_redirect %}
 {% if item.server_name_redirect is defined %}
 server {
-    {% if item.listen is not string and item.listen is iterable %}
+    {% if item.listen is defined and
+        item.listen is not string and
+        item.listen is iterable %}
         {% for listen in item.listen -%}
             listen {{ listen }};
             listen [::]:{{ listen }};
@@ -20,7 +22,9 @@ server {
     {% block server_begin %}{% endblock %}
 
     {% block server_basic -%}
-    {% if item.listen is not string and item.listen is iterable %}
+    {% if item.listen is defined and
+        item.listen is not string and
+        item.listen is iterable %}
         {% for listen in item.listen -%}
             listen {{ listen }};
             listen [::]:{{ listen }};

--- a/templates/vhost.j2
+++ b/templates/vhost.j2
@@ -1,8 +1,15 @@
 {% block server_redirect %}
 {% if item.server_name_redirect is defined %}
 server {
-    listen       {{ item.listen | default('80') }};
-    listen       [::]:{{item.listen | default('80') }};
+    {% if item.listen is not string and item.listen is iterable %}
+        {% for listen in item.listen -%}
+            listen {{ listen }};
+            listen [::]:{{ listen }};
+        {% endfor %}
+    {% else %}
+        listen       {{ item.listen | default('80') }};
+        listen       [::]:{{item.listen | default('80') }};
+    {% endif %}
     server_name  {{ item.server_name_redirect }};
     return       301 $scheme://{{ item.server_name.split(' ')[0] }}$request_uri;
 }
@@ -13,8 +20,15 @@ server {
     {% block server_begin %}{% endblock %}
 
     {% block server_basic -%}
-    listen {{ item.listen | default('80') }};
-    listen [::]:{{item.listen | default('80') }};
+    {% if item.listen is not string and item.listen is iterable %}
+        {% for listen in item.listen -%}
+            listen {{ listen }};
+            listen [::]:{{ listen }};
+        {% endfor %}
+    {% else %}
+        listen       {{ item.listen | default('80') }};
+        listen       [::]:{{item.listen | default('80') }};
+    {% endif %}
 
 {% if item.server_name is defined %}
     server_name {{ item.server_name }};


### PR DESCRIPTION
For ease of use and backwards compatibility the former way is still supported, i.e. only supplying a string.